### PR TITLE
Makefile: allow for EXTRA_CXXFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OBJ_FIXES=git-fixes.o
 OBJ_SUSE=git-suse.o
 OBJ_WHO=git-who.o who.o
-CXXFLAGS=-O3 -Wall -std=c++11
+CXXFLAGS=-O3 -Wall -std=c++11 $(EXTRA_CXXFLAGS)
 TARGET_FIXES=git-fixes
 TARGET_SUSE=git-suse
 TARGET_WHO=git-who


### PR DESCRIPTION
This is useful when building in OBS to pass in extra compiler options.

In particular, easy passing of RPM_OPT_FLAGS from .spec file while turning on/off the debug.