### PR TITLE
git-suse: Add Alt-commit tag for duplicate commit ids

### DIFF
--- a/git-suse.cc
+++ b/git-suse.cc
@@ -228,7 +228,8 @@ static void parse_patch(const string &path,
 
 		token = to_lower(line.substr(0, pos));
 
-		if (token == "git-commit" || token == "no-fix") {
+		if (token == "git-commit" || token == "no-fix" ||
+		    token == "alt-commit") {
 			string id;
 
 			pos = line.find_first_not_of(" ", pos + 1);
@@ -245,7 +246,7 @@ static void parse_patch(const string &path,
 				continue;
 
 			id = line.substr(pos, pos2 - pos);
-			if (token == "git-commit")
+			if (token == "git-commit" || token == "alt-commit")
 				commit_ids.emplace_back(id);
 			else
 				blacklist.emplace(id);


### PR DESCRIPTION
Sometimes patches have multiple commit ids associated with them. This is
often due to cherry picking between branches. By adding alternative
commit ids with the Alt-commit tag git-fixes can find fixes for all of
the specified commit ids.

Signed-off-by: Patrik Jakobsson <pjakobsson@suse.de>