### PR TITLE
patches: make the script python version agnostic

### DIFF
--- a/patches
+++ b/patches
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 
+from __future__ import print_function
 import getopt
 import string
 import sys
@@ -10,8 +11,7 @@ def is_git_commit(token):
 	if (len(token) != 40):
 		return False;
 	for c in token:
-		f = string.find(string.hexdigits, c);
-		if f == -1:
+		if c not in string.hexdigits:
 			return False;
 
 	return True;
@@ -57,7 +57,7 @@ def parse_patch_file(file_name):
 
 	ret = list();
 	for item in temp_list:
-		print item + str(",") + committer;
+		print(item + str(",") + committer);
 
 	return ret;
 


### PR DESCRIPTION
The current version of `patches` scripts runs only with `python2`.  With this patch it will run in both `python2` and `python3`.  On top of that I observe ~20 % speedup.

Tested with Python versions 2.7.13 (SLE12-SP3) and 3.11.4 (openSUSE Tumbleweed).

